### PR TITLE
Change volname to supplied mount_point on macos

### DIFF
--- a/oxfs/oxfs.py
+++ b/oxfs/oxfs.py
@@ -346,7 +346,8 @@ class Oxfs(LoggingMixIn, Operations):
                         uid=os.getuid(), gid=os.getgid(),
                         defer_permissions=True, kill_on_unmount=True,
                         noappledouble=True, noapplexattr=True,
-                        nosuid=True, nobrowse=True, volname=self.host)
+                        nosuid=True, nobrowse=True, 
+                        volname=os.path.basename(os.path.normpath(mount_point))
         elif 'Linux' == self.sys:
             fuse = FUSE(self, mount_point, foreground=True, nothreads=True,
                         allow_other=True, auto_cache=True,


### PR DESCRIPTION
On macos the current code mounts the volume (what you see in the finder) as the host name rather than as the supplied `mount_point` string.

This PR changes that behavior so that the macos `volname` = the supplied `mount_point` string.